### PR TITLE
Sets block-drawer to be open by default.

### DIFF
--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -38,7 +38,7 @@ user_preference_allow_ajax_update('drawer-open-block', PARAM_BOOL);
 
 if (isloggedin()) {
     $courseindexopen = (get_user_preferences('drawer-open-index', true) == true);
-    $blockdraweropen = (get_user_preferences('drawer-open-block') == true);
+    $blockdraweropen = (get_user_preferences('drawer-open-block', true) == true);
 } else {
     $courseindexopen = false;
     $blockdraweropen = false;

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2023050500;
+$plugin->version = 2023050900;
 $plugin->release = 'v4.1-beta';
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 401];


### PR DESCRIPTION
Moodle 3 has a fixed, right-hand rail for blocks.
In its place, Moodle 4 has a collapsible drawer for blocks. That block-drawer is/was closed by default.
This tripped up some of our users when evaluating Moodle 4 in preparation for the upgrade. "My blocks are gone!!"
In order to make this transition less jarring, let's make the drawer opened by default.