### PR TITLE
force main content area on course pages to claim as much horizontal space as available.

### DIFF
--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -2,4 +2,4 @@
 
 /* Make the content area use all the available space */
 /* @link https://www.youtube.com/watch?v=bs1AU_9yrOM */
-$course-content-maxwidth: 100% !default;
+$course-content-maxwidth: 100%;

--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -1,1 +1,5 @@
 // Pre SCSS for the theme.
+
+/* Make the content area use all the available space */
+/* @link https://www.youtube.com/watch?v=bs1AU_9yrOM */
+$course-content-maxwidth: 100% !default;

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2023051600;
+$plugin->version = 2023051601;
 $plugin->release = 'v4.1-beta';
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 401];


### PR DESCRIPTION
![image (2)](https://github.com/ucsf-education/moodle-theme-ucsf/assets/1410427/0764bd9b-0587-48fd-831a-baeb5fc59a0c)
![image (1)](https://github.com/ucsf-education/moodle-theme-ucsf/assets/1410427/2876ee7b-8348-42aa-a232-278f7e988dc2)
