### PR TITLE
rm expand/collapse-all controls from the blocks drawer.

### DIFF
--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -91,9 +91,6 @@
             {{$tooltipplacement}}left{{/tooltipplacement}}
             {{$drawercloseonresize}}1{{/drawercloseonresize}}
             {{$closebuttontext}}{{#str}}closeblockdrawer, core{{/str}}{{/closebuttontext}}
-            {{$drawercontentcontrols}}
-                {{> theme_ucsf/courseindexdrawercontrols}}
-            {{/drawercontentcontrols}}
         {{/ theme_ucsf/drawer}}
     {{/hasblocks}}
     <div id="page" data-region="mainpage" data-usertour="scroller" class="drawers {{#courseindexopen}}show-drawer-left{{/courseindexopen}} {{#blockdraweropen}}show-drawer-right{{/blockdraweropen}} drag-container">

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2023060501;
+$plugin->version = 2023060700;
 $plugin->release = 'v4.1-beta';
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 401];


### PR DESCRIPTION
bugfix: these shouldn't have been there in the first place.