### PR TITLE
replaces usage of deprecated "media" CSS classes with supported equivalents.

### DIFF
--- a/templates/course-hint-guestaccess.mustache
+++ b/templates/course-hint-guestaccess.mustache
@@ -32,9 +32,9 @@
     }
 }}
 <div class="course-hint-guestaccess alert alert-warning">
-    <div class="media">
-        <div class="me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
-        <div class="media-body align-self-center">
+    <div class="d-flex">
+        <div class="flex-shrink-0 me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="flex-grow-1 align-self-center">
             {{#str}} showhintcourseguestaccessgeneral, theme_ucsf, { "role": "{{role}}" } {{/str}}
             {{#showselfenrollink}}
                 <br>{{#str}} showhintcourseguestaccesslink, theme_ucsf, { "url": "{{config.wwwroot}}/enrol/index.php?id={{courseid}}" } {{/str}}

--- a/templates/course-hint-hidden.mustache
+++ b/templates/course-hint-hidden.mustache
@@ -30,9 +30,9 @@
     }
 }}
 <div class="course-hint-hidden alert alert-warning">
-    <div class="media">
-        <div class="me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
-        <div class="media-body align-self-center">
+    <div class="d-flex">
+        <div class="flex-shrink-0 me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="flex-grow-1 align-self-center">
             {{#str}} showhintcoursehiddengeneral, theme_ucsf {{/str}}
             {{#showcoursesettingslink}}
                 <br>{{#str}} showhintcoursehiddensettingslink, theme_ucsf, { "url": "{{config.wwwroot}}/course/edit.php?id={{courseid}}" } {{/str}}

--- a/templates/course-hint-switchedrole.mustache
+++ b/templates/course-hint-switchedrole.mustache
@@ -32,9 +32,9 @@
     }
 }}
 <div class="course-hint-switchedrole alert alert-info">
-    <div class="media">
-        <div class="me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
-        <div class="media-body align-self-center">
+    <div class="d-flex">
+        <div class="flex-grow-0 me-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="flex-grow-1 align-self-center">
             {{#str}} switchedroleto, theme_ucsf, { "role": "{{role}}" } {{/str}}
             <br><a href="{{{url}}}" class="switched-role-backlink">{{#str}} switchrolereturn, core {{/str}}</a>
         </div>

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2025021400;
+$plugin->version = 2025021401;
 $plugin->release = 'v4.5';
 $plugin->requires = 2024100100;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
before (M4.4)

![image](https://github.com/user-attachments/assets/9d61eaa2-ccf0-46fa-8c68-5dc48a7529d3)


after (M4.5)

![image](https://github.com/user-attachments/assets/58b9d906-9d4b-4e10-9713-e06b6ce4eb0b)
